### PR TITLE
Receive logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.116"
 tokio-tun = "0.3.16"
 futures = "0.3.19"
 bytes = "1"
-clap = { version = "3.1.5", features = ["derive"] }
+clap = { version = "3.2.22", features = ["derive"] }
 bincode = "1.3.3"
 pcap = { git = "https://github.com/drblah/pcap", branch = "async_wrappable" }
 lz4_flex = { version = "0.9.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ clap = { version = "3.1.5", features = ["derive"] }
 bincode = "1.3.3"
 pcap = { git = "https://github.com/drblah/pcap", branch = "async_wrappable" }
 lz4_flex = { version = "0.9.3" }
+simplelog = "0.12.0"
+log = "0.4.17"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(io_error_more)]
 #[macro_use] extern crate log;
 
 use bytes::BytesMut;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn main() {
 
     let mut maintenance_interval = time::interval(Duration::from_secs(5));
     let mut keepalive_interval = time::interval(Duration::from_secs(settings.keep_alive_interval));
-    let mut packet_deadline = time::interval(Duration::from_millis(5));
+    let mut packet_deadline = time::interval(Duration::from_millis(100));
 
     let bincode_config = bincode::options().with_varint_encoding().allow_trailing_bytes();
 
@@ -152,8 +152,10 @@ async fn main() {
 
                      */
 
+                    println!("Got seq {} in {}", packet.seq, receiver_interface);
+
                     sequencer.insert_packet(packet);
-                    
+
                     while sequencer.have_next_packet() {
 
                         if let Some(next_packet) = sequencer.get_next_packet() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ use tokio::fs::File as tokioFile;
 
 use simplelog::*;
 use std::fs::File;
-use std::io::Write;
 
 mod async_pcap;
 mod local;
@@ -40,7 +39,7 @@ struct Args {
     debug: bool
 }
 
-async fn await_remotes_receive(remotes: &mut Vec<Remote>, peer_list: &RwLock<PeerList>, debug_flag: bool) -> (Option<Packet>, String) {
+async fn await_remotes_receive(remotes: &mut Vec<Remote>, peer_list: &RwLock<PeerList>) -> (Option<Packet>, String) {
     let futures = FuturesUnordered::new();
     let mut interfaces = Vec::new();
 
@@ -126,7 +125,7 @@ async fn main() {
     loop {
         tokio::select! {
 
-            (socket_result, receiver_interface) = await_remotes_receive(&mut remotes, &peer_list, args.debug) => {
+            (socket_result, receiver_interface) = await_remotes_receive(&mut remotes, &peer_list) => {
                 if let Some(packet) = socket_result {
                     if packet.seq > rx_counter {
                         if args.debug {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use bytes::BytesMut;
 use futures::future::select_all;
 use futures::{FutureExt, StreamExt};
 use std::net::SocketAddr;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration};
 use bincode::Options;
 
 use crate::messages::{Messages, Packet};
@@ -117,7 +117,6 @@ async fn main() {
     let mut tun_buf = BytesMut::with_capacity(65535);
 
     let mut tx_counter: usize = 0;
-    let mut rx_counter: usize = 0;
 
     let peer_list = RwLock::new(PeerList::new(Some(settings.peers)));
     let mut sequencer = Sequencer::new(Duration::from_millis(3));

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,10 +32,10 @@ mod settings;
 #[clap(author, version, about)]
 struct Args {
     /// Path to the configuration file
-    #[clap(long)]
+    #[clap(long, action = clap::ArgAction::Set)]
     config: String,
 
-    #[clap(long)]
+    #[clap(long, action = clap::ArgAction::SetTrue)]
     debug: bool
 }
 

--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -55,7 +55,7 @@ impl PeerList {
         }
     }
 
-    pub fn get_peers(&mut self) -> Vec<SocketAddr> {
+    pub fn get_peers(&self) -> Vec<SocketAddr> {
         self.peers
             .values()
             .cloned()

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+use std::fmt::Formatter;
 use crate::settings::RemoteTypes;
 use crate::{Messages, PeerList};
 use bytes::{Bytes, BytesMut};
@@ -27,6 +29,7 @@ pub enum RemoteWriters {
 pub struct Remote {
     pub reader: RemoteReaders,
     pub writer: RemoteWriters,
+    interface: String
 }
 
 impl Remote {
@@ -47,6 +50,7 @@ impl Remote {
                 Remote {
                     reader: RemoteReaders::UDPReader(reader),
                     writer: RemoteWriters::UDPWriter(writer),
+                    interface: iface
                 }
             }
             RemoteTypes::UDPLz4 {
@@ -64,6 +68,7 @@ impl Remote {
                 Remote {
                     reader: RemoteReaders::UDPReaderLz4(reader),
                     writer: RemoteWriters::UDPWriterLz4(writer),
+                    interface: iface
                 }
             }
         }
@@ -115,6 +120,10 @@ impl Remote {
             RemoteWriters::UDPWriterLz4(_) => udp_keepalive(self, peer_list).await,
             _ => {}
         }
+    }
+
+    pub fn get_interface(&self) -> String {
+        self.interface.clone()
     }
 }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-use std::fmt::Formatter;
 use crate::settings::RemoteTypes;
 use crate::{Messages, PeerList};
 use bytes::{Bytes, BytesMut};
@@ -86,8 +84,6 @@ impl Remote {
                         }
                     }
                 }
-
-                //udp_writer.send((buffer, destination)).await.unwrap()
             }
             RemoteWriters::UDPWriterLz4(udplz4_writer) => {
                 let compressed = compress_prepend_size(&buffer[..]);
@@ -127,8 +123,7 @@ impl Remote {
     pub async fn keepalive(&mut self, peer_list: &mut PeerList) {
         match &mut self.writer {
             RemoteWriters::UDPWriter(_) => udp_keepalive(self, peer_list).await,
-            RemoteWriters::UDPWriterLz4(_) => udp_keepalive(self, peer_list).await,
-            _ => {}
+            RemoteWriters::UDPWriterLz4(_) => udp_keepalive(self, peer_list).await
         }
     }
 

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -45,6 +45,8 @@ impl Sequencer {
                 let only_packet = self.packet_queue.first_entry().unwrap();
                 self.next_seq = *only_packet.key();
             }
+        } else {
+            println!("Sequencer: Not inserting seq id: {}, because self.next_seq is: {}", pkt.seq, self.next_seq)
         }
     }
 

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -36,11 +36,6 @@ impl Sequencer {
         if pkt.seq >= self.next_seq {
             self.packet_queue.entry(pkt.seq)
                 .or_insert(pkt);
-
-            //if self.packet_queue.len() == 1 {
-            //    let only_packet = self.packet_queue.first_entry().unwrap();
-            //    self.next_seq = *only_packet.key();
-            //}
         }
     }
 
@@ -50,7 +45,6 @@ impl Sequencer {
 
         if !self.packet_queue.is_empty() {
             self.next_seq = *self.packet_queue.first_entry().unwrap().key();
-            //println!("Deadline reached, have set new next_seq: {}", self.next_seq);
         }
     }
 

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -1,0 +1,155 @@
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime};
+use crate::Packet;
+
+#[derive(Debug)]
+pub struct TimestampedPacket {
+    packet: Packet,
+    timestamp: SystemTime
+}
+
+#[derive(Debug)]
+pub struct Sequencer {
+    packet_queue: BTreeMap<usize, TimestampedPacket>,
+    pub next_seq: usize,
+    deadline: Duration
+}
+
+impl Sequencer {
+    pub fn new(deadline: Duration) -> Self {
+        Sequencer{
+            packet_queue: BTreeMap::new(),
+            next_seq: 0,
+            deadline
+        }
+    }
+
+    pub fn get_next_packet(&mut self) -> Option<Packet> {
+        if let Some(entry) = self.packet_queue.first_entry() {
+            if *entry.key() == self.next_seq {
+                self.next_seq += 1;
+                let ts_pkt = self.packet_queue.pop_first().unwrap().1;
+                return Some(ts_pkt.packet)
+            }
+        }
+
+        None
+    }
+
+    pub fn insert_packet(&mut self, pkt: Packet) {
+        self.packet_queue.entry(pkt.seq)
+            .or_insert(TimestampedPacket{packet: pkt, timestamp: SystemTime::now()});
+
+        if self.packet_queue.len() == 1 {
+            let only_packet = self.packet_queue.first_entry().unwrap();
+            self.next_seq = *only_packet.key();
+        }
+    }
+
+    pub fn prune_outdated(&mut self) {
+        let now = SystemTime::now();
+
+        //println!("Beginning prune. packet queue before prune: {:?}", self.packet_queue);
+
+        self.packet_queue.retain(|_, ts_pkt| {
+            now.duration_since(ts_pkt.timestamp)
+                .unwrap()
+                .lt(&self.deadline)
+        });
+
+        //println!("After prune: {:?}", self.packet_queue);
+
+        // Update packet sequence counter to current lowest number
+        if let Some(pkt) = self.packet_queue.first_entry() {
+            //println!("About to update next seq during pruning: {:?}", self.next_seq);
+            self.next_seq = *pkt.key();
+            //println!("New next seq: {:?}", self.next_seq);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+    use std::time::Duration;
+    use crate::{Packet, Sequencer};
+
+    #[test]
+    fn unordered_insert() {
+        let mut sequencer = Sequencer::new(Duration::from_millis(1));
+        let packets = vec![
+            Packet{
+                seq: 0,
+                bytes: Vec::new()
+            },
+            Packet {
+                seq: 3,
+                bytes: Vec::new()
+            },
+            Packet{
+                seq: 1,
+                bytes: Vec::new()
+            },
+            Packet{
+                seq: 2,
+                bytes: Vec::new()
+            }
+        ];
+        let expected = [0, 1, 2, 3];
+
+        for packet in packets{
+            sequencer.insert_packet(packet)
+        }
+
+        for expected_seq in expected {
+            let pkt = sequencer.get_next_packet().unwrap();
+
+            assert_eq!(pkt.seq, expected_seq)
+        }
+    }
+
+    #[test]
+    fn unordered_sequence_hole_insert() {
+        let mut sequencer = Sequencer::new(Duration::from_millis(100));
+        let packets = vec![
+            Packet {
+                seq: 3,
+                bytes: Vec::new()
+            },
+            Packet{
+                seq: 2,
+                bytes: Vec::new()
+            },
+            Packet{
+                seq: 4,
+                bytes: Vec::new()
+            }
+        ];
+        let expected: [usize; 4] = [0, 2, 3, 4];
+
+        sequencer.insert_packet(
+            Packet{
+                seq: 0,
+                bytes: Vec::new()
+            }
+        );
+
+        // Sleep to allow the first packet to exceed the deadline
+        thread::sleep(Duration::from_millis(150));
+
+        for packet in packets{
+            sequencer.insert_packet(packet)
+        }
+
+        for expected_seq in expected {
+            if let Some(pkt) = sequencer.get_next_packet() {
+                assert_eq!(pkt.seq, expected_seq)
+            } else {
+                sequencer.prune_outdated();
+                if let Some(pkt) = sequencer.get_next_packet() {
+                    assert_eq!(pkt.seq, expected_seq)
+                }
+            }
+        }
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -35,4 +35,5 @@ pub struct SettingsFile {
     pub keep_alive_interval: u64,
     pub local: LocalTypes,
     pub remotes: Vec<RemoteTypes>,
+    pub reorder: bool
 }

--- a/test_tools/l2-many-to-one/host1.json
+++ b/test_tools/l2-many-to-one/host1.json
@@ -4,6 +4,7 @@
   ],
   "keep_alive": true,
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer2",
     "network_interface": "gw_veth1"

--- a/test_tools/l2-many-to-one/host2.json
+++ b/test_tools/l2-many-to-one/host2.json
@@ -2,6 +2,7 @@
   "peers": [
   ],
   "keep_alive_interval": 15,
+  "reorder": true,
   "local": {
     "type": "Layer2",
     "network_interface": "gw_veth2"

--- a/test_tools/many-to-one-lz4/host1.json
+++ b/test_tools/many-to-one-lz4/host1.json
@@ -3,6 +3,7 @@
     "172.16.200.4:10001"
   ],
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer3",
     "tun_ip": "10.12.0.1",

--- a/test_tools/many-to-one-lz4/host2.json
+++ b/test_tools/many-to-one-lz4/host2.json
@@ -3,6 +3,7 @@
     "172.16.200.2:10000"
   ],
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer3",
     "tun_ip": "10.12.0.2"

--- a/test_tools/many-to-one-netem/host1.json
+++ b/test_tools/many-to-one-netem/host1.json
@@ -3,6 +3,7 @@
     "172.16.200.4:10001"
   ],
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer3",
     "tun_ip": "10.12.0.1",

--- a/test_tools/many-to-one-netem/host2.json
+++ b/test_tools/many-to-one-netem/host2.json
@@ -3,6 +3,7 @@
     "172.16.200.2:10000"
   ],
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer3",
     "tun_ip": "10.12.0.2"

--- a/test_tools/many-to-one/host1.json
+++ b/test_tools/many-to-one/host1.json
@@ -3,6 +3,7 @@
     "172.16.200.4:10001"
   ],
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer3",
     "tun_ip": "10.12.0.1",

--- a/test_tools/many-to-one/host2.json
+++ b/test_tools/many-to-one/host2.json
@@ -1,8 +1,8 @@
 {
   "peers": [
-
   ],
   "keep_alive_interval": 10,
+  "reorder": true,
   "local": {
     "type": "Layer3",
     "tun_ip": "10.12.0.2"


### PR DESCRIPTION
This PR includes two major new features:

### Receive logging
Introduces the --debug flag when starting mpconn. This causes mpconn to create a log file which stores information about when a Remote recieves a packet. This is useful for providing insight into the behavior of the underlying network layer and the route. The log file contains a timestamp, sequence number and interface which received the packet.

### Reordering
In cases where the underlying network does not guarantee in-sequence packet delivery, multi-connectivity can be broken.. Therefore, mpconn now has an optional "Sequencer" module which can correct the ordering of received packages at the cost of increased latency. The Sequencer supports a configurable window in which it will wait for out-of-sequence packages, before declaring them lost.