### PR TITLE
inferface log name change

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,9 @@ async fn main() {
     let mut duplication_logger: Option<BufWriter<File>> = Option::None;
 
     if args.debug {
-        interface_logger = Some(BufWriter::new(File::create("interface.log").await.unwrap()));
+        let system_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
+        let filename = format!("{}_{}",system_time,"interface.log");
+        interface_logger = Some(BufWriter::new(File::create(filename).await.unwrap()));
         duplication_logger = Some(BufWriter::new(File::create("duplication.log").await.unwrap()));
 
         if let Some(if_log) = &mut interface_logger {

--- a/src/nic_metric.rs
+++ b/src/nic_metric.rs
@@ -1,4 +1,3 @@
-use alloc::fmt::format;
 use std::thread;
 use std::time::Duration;
 use tokio::sync::watch;


### PR DESCRIPTION
Changed interface log name so that it includes a timestamp and it does not overwrite when re-running mpconn.